### PR TITLE
Add custom Seal Order handling to Diablo and DiabloHelper

### DIFF
--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -2,6 +2,7 @@
 *	@filename	Diablo.js
 *	@author		kolton
 *	@desc		clear Chaos Sanctuary and kill Diablo
+*   @return {boolean}
 */
 
 function Diablo() {
@@ -235,6 +236,7 @@ function Diablo() {
 	};
 
 	this.infectorSeal = function () {
+		Precast.doPrecast(true);
 		print("Inf layout " + this.infLayout);
 		this.followPath(this.infLayout === 1 ? this.starToInfA : this.starToInfB);
 
@@ -259,9 +261,33 @@ function Diablo() {
 		return true;
 	};
 
+	const openSeals = (sealOrder) => {
+		print("seal order: " + sealOrder);
+		let seals = {
+			1: () => this.vizierSeal(),
+			2: () => this.seisSeal(),
+			3: () => this.infectorSeal(),
+			"vizier": () => this.vizierSeal(),
+			"seis": () => this.seisSeal(),
+			"infector": () => this.infectorSeal(),
+		};
+		sealOrder.forEach(seal => {seals[seal]()});
+	};
+
 	this.diabloPrep = function () {
 		var trapCheck,
 			tick = getTickCount();
+
+		switch (me.classid) {
+			case 1:
+				Pather.moveTo(7792, 5294);
+
+				break;
+			default:
+				Pather.moveTo(7788, 5292);
+
+				break;
+		}
 
 		while (getTickCount() - tick < 30000) {
 			if (getTickCount() - tick >= 8000) {
@@ -431,7 +457,7 @@ function Diablo() {
 		Pather.useWaypoint(107);
 	}
 
-	if (!Pather.moveTo(7790, 5544)) {
+	if (!Pather.moveTo(7790, 5544, 5, Config.ClearPath)) {
 		throw new Error("Failed to move to Chaos Sanctuary");
 	}
 
@@ -439,7 +465,7 @@ function Diablo() {
 
 	if (Config.Diablo.Entrance) {
 		Attack.clear(30, 0, false, this.sort);
-		Pather.moveTo(7790, 5544);
+		Pather.moveTo(7790, 5544, 3, Config.ClearPath);
 
 		if (Config.PublicMode) {
 			Pather.makePortal();
@@ -447,16 +473,16 @@ function Diablo() {
 			Pather.teleport = !Config.Diablo.WalkClear && Pather._teleport;
 		}
 
-		Pather.moveTo(7790, 5544);
+		Pather.moveTo(7790, 5544, 5, Config.ClearPath);
 		Precast.doPrecast(true);
 		Attack.clear(30, 0, false, this.sort);
 		this.followPath(this.entranceToStar);
 	} else {
-		Pather.moveTo(7774, 5305);
+		Pather.moveTo(7774, 5305, 5, Config.ClearPath);
 		Attack.clear(15, 0, false, this.sort);
 	}
 
-	Pather.moveTo(7791, 5293);
+	Pather.moveTo(7791, 5293, 5, Config.ClearPath);
 
 	if (Config.PublicMode) {
 		Pather.makePortal();
@@ -465,28 +491,23 @@ function Diablo() {
 	}
 
 	Attack.clear(30, 0, false, this.sort);
-	this.vizierSeal();
-	this.seisSeal();
-	Precast.doPrecast(true);
-	this.infectorSeal();
-
-	switch (me.classid) {
-	case 1:
-		Pather.moveTo(7792, 5294);
-
-		break;
-	default:
-		Pather.moveTo(7788, 5292);
-
-		break;
-	}
-
+	openSeals(Config.Diablo.SealOrder);
 
 	if (Config.PublicMode) {
 		say(Config.Diablo.DiabloMsg);
 	}
 
-	this.diabloPrep();
+	try {
+		print("Attempting to find Diablo");
+		this.diabloPrep();
+	} catch (error) {
+		print("Diablo wasn't found. Checking seals.");
+		this.vizierSeal();
+		this.seisSeal();
+		this.infectorSeal();
+		this.diabloPrep();
+	}
+
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 

--- a/d2bs/kolbot/libs/bots/DiabloHelper.js
+++ b/d2bs/kolbot/libs/bots/DiabloHelper.js
@@ -223,7 +223,7 @@ function DiabloHelper() {
 		return true;
 	};
 
-	const openSeals = (sealOrder) => {
+	const clearSeals = (sealOrder) => {
 		print("seal order: " + sealOrder);
 		let seals = {
 			1: () => this.vizierSeal(),
@@ -546,7 +546,7 @@ CSLoop:
 
 	Pather.moveTo(7774, 5305);
 	Attack.clear(35, 0, false, this.sort);
-	openSeals(Config.DiabloHelper.SealOrder);
+	clearSeals(Config.DiabloHelper.SealOrder);
 
 	try {
 		print("Attempting to find Diablo");

--- a/d2bs/kolbot/libs/bots/DiabloHelper.js
+++ b/d2bs/kolbot/libs/bots/DiabloHelper.js
@@ -2,6 +2,7 @@
 *	@filename	DiabloHelper.js
 *	@author		kolton
 *	@desc		help leading player in clearing Chaos Sanctuary and killing Diablo
+*   @return {boolean}
 */
 
 function DiabloHelper() {
@@ -72,6 +73,43 @@ function DiabloHelper() {
 		this.infLayout = this.getLayout(392, 7893); // 1 = "I", 2 = "J"
 	};
 
+	this.openSeal = function (classid) {
+		let i,
+			seal;
+
+		for (i = 0; i < 5; i += 1) {
+			Pather.moveToPreset(108, 2, classid, classid === 394 ? 5 : 2, classid === 394 ? 5 : 0);
+
+			seal = getUnit(2, classid);
+
+			if (!seal) {
+				return false;
+			}
+
+			if (classid === 394) {
+				Misc.click(0, 0, seal);
+			} else {
+				seal.interact();
+			}
+
+			delay(classid === 394 ? 1000 : 500);
+
+			if (!seal.mode) {
+				if (classid === 394 && Attack.validSpot(seal.x + 15, seal.y)) { // de seis optimization
+					Pather.moveTo(seal.x + 15, seal.y);
+				} else {
+					Pather.moveTo(seal.x - 5, seal.y - 5);
+				}
+
+				delay(500);
+			} else {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
 	this.getBoss = function (name) {
 		var i, boss, glow;
 
@@ -103,6 +141,12 @@ function DiabloHelper() {
 	this.vizierSeal = function () {
 		this.followPath(this.vizLayout === 1 ? this.starToVizA : this.starToVizB, this.sort);
 
+		if (Config.DiabloHelper.OpenSeals) {
+			if (!this.openSeal(395) || !this.openSeal(396)) {
+				throw new Error("Failed to open Vizier seals.");
+			}
+		}
+
 		if (this.vizLayout === 1) {
 			Pather.moveTo(7691, 5292);
 		} else {
@@ -123,6 +167,12 @@ function DiabloHelper() {
 	this.seisSeal = function () {
 		this.followPath(this.seisLayout === 1 ? this.starToSeisA : this.starToSeisB, this.sort);
 
+		if (Config.DiabloHelper.OpenSeals) {
+			if (!this.openSeal(394)) {
+				throw new Error("Failed to open de Seis seal.");
+			}
+		}
+
 		if (this.seisLayout === 1) {
 			Pather.moveTo(7771, 5196);
 		} else {
@@ -141,7 +191,14 @@ function DiabloHelper() {
 	};
 
 	this.infectorSeal = function () {
+		Precast.doPrecast(true);
 		this.followPath(this.infLayout === 1 ? this.starToInfA : this.starToInfB, this.sort);
+
+		if (Config.DiabloHelper.OpenSeals) {
+			if (!this.openSeal(392)) {
+				throw new Error("Failed to open Infector seals.");
+			}
+		}
 
 		if (this.infLayout === 1) {
 			delay(1);
@@ -153,6 +210,12 @@ function DiabloHelper() {
 			throw new Error("Failed to kill Infector");
 		}
 
+		if (Config.DiabloHelper.OpenSeals) {
+			if (!this.openSeal(393)) {
+				throw new Error("Failed to open Infector seals.");
+			}
+		}
+
 		if (Config.FieldID) {
 			Town.fieldID();
 		}
@@ -160,9 +223,33 @@ function DiabloHelper() {
 		return true;
 	};
 
+	const openSeals = (sealOrder) => {
+		print("seal order: " + sealOrder);
+		let seals = {
+			1: () => this.vizierSeal(),
+			2: () => this.seisSeal(),
+			3: () => this.infectorSeal(),
+			"vizier": () => this.vizierSeal(),
+			"seis": () => this.seisSeal(),
+			"infector": () => this.infectorSeal(),
+		};
+		sealOrder.forEach(seal => {seals[seal]()});
+	};
+
 	this.diabloPrep = function () {
 		var trapCheck,
 			tick = getTickCount();
+
+		switch (me.classid) {
+			case 1:
+				Pather.moveTo(7793, 5291);
+
+				break;
+			default:
+				Pather.moveTo(7788, 5292);
+
+				break;
+		}
 
 		while (getTickCount() - tick < 30000) {
 			if (getTickCount() - tick >= 8000) {
@@ -393,8 +480,10 @@ AreaInfoLoop:
 		}
 	}
 
-	Pather.useWaypoint(Config.RandomPrecast ? "random" : 107);
-	Precast.doPrecast(true);
+	if (Config.DiabloHelper.SafePrecast) {
+		Pather.useWaypoint(Config.RandomPrecast ? "random" : 107);
+		Precast.doPrecast(true);
+	}
 
 	if (Config.DiabloHelper.SkipTP) {
 		if (me.area !== 107) {
@@ -457,23 +546,19 @@ CSLoop:
 
 	Pather.moveTo(7774, 5305);
 	Attack.clear(35, 0, false, this.sort);
-	this.vizierSeal();
-	this.seisSeal();
-	Precast.doPrecast(true);
-	this.infectorSeal();
+	openSeals(Config.DiabloHelper.SealOrder);
 
-	switch (me.classid) {
-	case 1:
-		Pather.moveTo(7793, 5291);
-
-		break;
-	default:
-		Pather.moveTo(7788, 5292);
-
-		break;
+	try {
+		print("Attempting to find Diablo");
+		this.diabloPrep();
+	} catch (error) {
+		print("Diablo wasn't found. Checking seals.");
+		this.vizierSeal();
+		this.seisSeal();
+		this.infectorSeal();
+		this.diabloPrep();
 	}
 
-	this.diabloPrep();
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -405,13 +405,17 @@ var Config = {
 		EntranceTP: "Entrance TP up",
 		StarTP: "Star TP up",
 		DiabloMsg: "Diablo",
-		WalkClear: false
+		WalkClear: false,
+		SealOrder: ["vizier", "seis", "infector"],
 	},
 	DiabloHelper: {
 		Wait: 120,
 		Entrance: false,
 		SkipIfBaal: false,
-		SkipTP: false
+		SkipTP: false,
+		OpenSeals: false,
+		SafePrecast: true,
+		SealOrder: ["vizier", "seis", "infector"],
 	},
 	BattleOrders: {
 		Mode: 0,

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -88,6 +88,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +142,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot


### PR DESCRIPTION
There are two scenarios where a custom seal order comes in handy, that I've found:
1. You want to clear the seals as fast as possible and just get to Diablo (for mf). With multiple bots, they can each take a seal or two, and meet up at Diablo when the seals have been finished.
2. Your bot struggles with a specific seal boss and you want to do things in a certain order. You can put the boss the bot struggles on last in the order and if it does end up chickening, the run won't end too quickly and cause realmdown.

Additional config vars added in this change:
`Config.DiabloHelper.OpenSeals` // This allows you to control whether or not a helper will open seals. Useful for if your helper is assign seal x and the main bot is assigned seal y, z.  (default: false)
`Config.DiabloHelper.SafePrecast` // Previously, helpers would _always_ warp to a random WP and precast, but they'd also precast during their run. If you want to disable their safe precast, set this to `false` (default: true)

Implementation details:
`SealOrder` is checked to see if a specific order has been defined. The default order is the old order, viz/seis/infector. If a user defined order is in place, that order is followed. The order is respected even
if less than three seals are listed. If Diablo is not found, all the seals are checked in the default a second time.

`SealOrder` can contain seal bosses by name, or number. `1==vizier`, `2==seis`, and `3==infector`